### PR TITLE
Bugfix/approve and reject service providers

### DIFF
--- a/backend/django_backend/authentication/views.py
+++ b/backend/django_backend/authentication/views.py
@@ -108,7 +108,7 @@ def pending_service_providers(request):
 @api_view(['PATCH'])
 @permission_classes([IsAuthenticated, IsAdminUser])
 def approve_service_provider(request, user_uuid):
-    user = get_object_or_404(CustomUser, uuid=user_uuid, role=CustomUser.SERVICE_PROVIDER)
+    user = get_object_or_404(CustomUser, id=user_uuid, role=CustomUser.SERVICE_PROVIDER)
     user.is_approved = True
     user.save()
     return Response({'status': 'Service provider approved'})
@@ -116,6 +116,6 @@ def approve_service_provider(request, user_uuid):
 @api_view(['DELETE'])
 @permission_classes([IsAuthenticated, IsAdminUser])
 def delete_service_provider(request, user_uuid):
-    user = get_object_or_404(CustomUser, uuid=user_uuid, role=CustomUser.SERVICE_PROVIDER)
+    user = get_object_or_404(CustomUser, id=user_uuid, role=CustomUser.SERVICE_PROVIDER)
     user.delete()
     return Response({'status': 'Service provider deleted'}) 

--- a/frontend/dogplus-frontend/src/pages/adminDashboardPage.tsx
+++ b/frontend/dogplus-frontend/src/pages/adminDashboardPage.tsx
@@ -23,7 +23,7 @@ export const AdminDashboard = () => {
       })
       .then((data) => {
         if (Array.isArray(data)) {
-          setServiceProviders(data.map((item) => ({ ...item, id: item.uuid })));
+          setServiceProviders(data.map((item) => ({ ...item, id: item.id })));
         } else {
           setServiceProviders([]);
         }
@@ -32,7 +32,7 @@ export const AdminDashboard = () => {
 
   const approveServiceProvider = (userId: string) => {
     const token = localStorage.getItem("token");
-    const url = `${process.env.REACT_APP_BACKEND_HOST}/api/auth/service-providers/approve/${userId}`;
+    const url = `${process.env.REACT_APP_BACKEND_HOST}/api/auth/service-providers/approve/${userId}/`;
 
     fetch(url, {
       method: "PATCH",
@@ -51,7 +51,7 @@ export const AdminDashboard = () => {
 
   const rejectServiceProvider = (userId: string) => {
     const token = localStorage.getItem("token");
-    const url = `${process.env.REACT_APP_BACKEND_HOST}/api/auth/service-providers/delete/${userId}`;
+    const url = `${process.env.REACT_APP_BACKEND_HOST}/api/auth/service-providers/delete/${userId}/`;
 
     fetch(url, {
       method: "DELETE",


### PR DESCRIPTION
# Description

Fix of a bug appearing due to a refactor from using the name *uuid* to *id*. This made it impossible to approve and reject new service providers. 

# Feature
- [X] Can now approve and reject service providers from the admin dashboard again