### PR TITLE
made a mutable copy of request.data so that create-post works again

### DIFF
--- a/backend/django_backend/feed/views.py
+++ b/backend/django_backend/feed/views.py
@@ -15,9 +15,15 @@ class CreatePostAPIView(APIView):
         return Response(serializer.data)
 
     def post(self, request, format=None):
-        request.data['author'] = request.user.id
+        # Create a mutable copy of the request.data
+        mutable_data = request.data.copy()
+        mutable_data['author'] = request.user.id
 
-        serializer = PostSerializer(data=request.data, context={'request': request})
+        # Check if 'image' is included in the form data
+        if 'image' in request.FILES:
+            mutable_data['image'] = request.FILES['image']
+
+        serializer = PostSerializer(data=mutable_data, context={'request': request})
         if serializer.is_valid():
             serializer.save()
             return Response(serializer.data, status=status.HTTP_201_CREATED)


### PR DESCRIPTION
# Description
Havent bothered to find out what commit introduced this bug, but since request.data is immutable, the create-post endpoint was not working. Created a mutable copy and we now use this instead, so all should be good.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Interactively

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works

