### PR TITLE
[Fix] Redirect user to auth when not logged in on path '/'

### DIFF
--- a/frontend/dogplus-frontend/src/App.tsx
+++ b/frontend/dogplus-frontend/src/App.tsx
@@ -24,7 +24,7 @@ function App() {
         <Route path="auth" element={<LoginPage />} />
         <Route path="register" element={<RegisterPage />} />
         <Route
-          path="home"
+          path="/"
           element={
             <RequireAuth>
               <HomePage />

--- a/frontend/dogplus-frontend/src/RequireAuth.tsx
+++ b/frontend/dogplus-frontend/src/RequireAuth.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useTransition } from "react";
-import { Navigate, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import useUser from "./hooks/useUser";
 import { UserRole } from "./types/user";
 import { Loading } from "./components/common/loading";
@@ -32,7 +32,7 @@ const RequireAuth: React.FC<RequireAuthProps> = ({
       ) {
         navigate("/approval-pending", { replace: true });
       } else if (requiredRoles && user && !requiredRoles.includes(user.role)) {
-        navigate("/home", { replace: true });
+        navigate("/", { replace: true });
       }
     });
   }, [auth, user, requireServiceProviderApproval, requiredRoles, navigate]);

--- a/frontend/dogplus-frontend/src/components/common/navbar.tsx
+++ b/frontend/dogplus-frontend/src/components/common/navbar.tsx
@@ -19,7 +19,7 @@ export const Navbar = () => {
     <div className="fixed bottom-0 left-0 py-1 px-1 z-50 w-full h-16 bg-white border-t border-gray-200 dark:bg-gray-700 dark:border-gray-600">
       <nav className="grid h-full max-w-lg grid-cols-3 mx-auto font-medium gap-4">
         <NavLink
-          to="/home"
+          to="/"
           className={({ isActive }) =>
             isActive ? navlink_active : navlink_default
           }

--- a/frontend/dogplus-frontend/src/pages/loginPage.tsx
+++ b/frontend/dogplus-frontend/src/pages/loginPage.tsx
@@ -65,7 +65,7 @@ export const LoginPage = () => {
           navigate("/serviceprovider/dashboard");
           break;
         default:
-          navigate("/home");
+          navigate("/");
       }
     } catch (error) {
       setErrorMessage("Login failed. Please check your username and password.");

--- a/frontend/dogplus-frontend/src/pages/registerPage.tsx
+++ b/frontend/dogplus-frontend/src/pages/registerPage.tsx
@@ -120,7 +120,7 @@ export const RegisterPage = () => {
       } else if (data.role === UserRole.ServiceProvider) {
         navigate("/serviceprovider/create-service");
       } else {
-        navigate("/home");
+        navigate("/");
       }
     } catch (error) {
       setError("An error occurred during registration. Please try again.");


### PR DESCRIPTION
# Issue
On the root of the website, i.e. "/" nothing was shown. This is for instance an issue on the phone version of the app, since a PWA opens this first.

# Fix
Rename "/home" to "/"