### PR TITLE
[Fix] Booking deletion - Change endpoint to be POST instead of DELETE

### DIFF
--- a/backend/django_backend/bookings/urls.py
+++ b/backend/django_backend/bookings/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
-from .views import AvailableBookingsView, BookingView
+from .views import AvailableBookingsView, BookingView, DeleteBookingView
 
 urlpatterns = [
     path('', BookingView.as_view(), name='booking'),  # Handles posting a new booking
+    path('delete/<int:booking_id>/', DeleteBookingView.as_view(), name='booking-delete'),  # Handles delete for a specific booking
     path('<int:booking_id>/', BookingView.as_view(), name='booking-detail'),  # Handles delete for a specific booking
     path('available/<int:service_id>', AvailableBookingsView.as_view(), name='available-timeslots'),
 ]

--- a/backend/django_backend/bookings/views.py
+++ b/backend/django_backend/bookings/views.py
@@ -73,8 +73,10 @@ class BookingView(APIView):
         )
         return not existing_bookings.exists()
     
-    def delete(self, request, *args, **kwargs):
-        booking_id = kwargs.get('booking_id')
+
+
+class DeleteBookingView(APIView):
+    def post(self, request, booking_id, *args, **kwargs):
         try:
             # Allow deletion if the request user is the owner or the service provider of the booking
             booking = Booking.objects.get(id=booking_id)
@@ -85,7 +87,6 @@ class BookingView(APIView):
             
         booking.delete()
         return Response({"detail": "Booking successfully deleted."}, status=status.HTTP_204_NO_CONTENT)
-
 
 class AvailableBookingsView(APIView):
     permission_classes = [IsAuthenticated]

--- a/frontend/dogplus-frontend/src/components/serviceProvider/BookingsOverview.tsx
+++ b/frontend/dogplus-frontend/src/components/serviceProvider/BookingsOverview.tsx
@@ -56,12 +56,11 @@ export const BookingsOverview = () => {
   }, [user]);
 
   const handleDeleteBooking = async (bookingId: string) => {
-    toast.success("Booking deleted successfully!")
     try {
       const response = await fetch(
-        `${process.env.REACT_APP_BACKEND_HOST}/api/booking/${bookingId}/`,
+        `${process.env.REACT_APP_BACKEND_HOST}/api/booking/delete/${bookingId}/`,
         {
-          method: "DELETE",
+          method: "POST",
           headers: {
             Authorization: `Token ${localStorage.getItem("token")}`,
           },
@@ -73,6 +72,7 @@ export const BookingsOverview = () => {
         throw new Error("Failed to delete booking");
       }
 
+      toast.success("Booking deleted successfully!")
       if (!dashboardData) return;
       setDashboardData({
         ...dashboardData,


### PR DESCRIPTION
# Description
In google cloud, we had an issue where all DELETE request was being flagged. After countless hours of debugging I have figured out that the easiest way to fix this is to just change the request to be a POST request. 

This is is tested in google cloud and works