### PR TITLE
[FIX] Booking page only showing 3 possible booking times

### DIFF
--- a/frontend/dogplus-frontend/src/components/common/timeselector.tsx
+++ b/frontend/dogplus-frontend/src/components/common/timeselector.tsx
@@ -2,15 +2,16 @@ import React, { useState } from 'react';
 
 interface TimeSelectorProps {
   selectedTime: string;
+  timeInterval: number;
   onTimeChange: (time: string) => void;
 }
 
-const TimeSelector: React.FC<TimeSelectorProps> = ({ selectedTime, onTimeChange}) => {
+const TimeSelector: React.FC<TimeSelectorProps> = ({ selectedTime, timeInterval, onTimeChange}) => {
 
   const generateTimeOptions = (): string[] => {
     const options: string[] = [];
     for (let hour = 7; hour < 24; hour++) {
-      for (let minute = 0; minute < 60; minute += 30) {
+      for (let minute = 0; minute < 60; minute += timeInterval) {
         const formattedHour = hour.toString().padStart(2, '0');
         const formattedMinute = minute.toString().padStart(2, '0');
         options.push(`${formattedHour}:${formattedMinute}`);

--- a/frontend/dogplus-frontend/src/pages/serviceProviderBookingPage.tsx
+++ b/frontend/dogplus-frontend/src/pages/serviceProviderBookingPage.tsx
@@ -8,6 +8,7 @@ import { Service } from '../types/services';
 import { toast } from 'react-hot-toast';
 import { Label } from '../components/label';
 
+const end_time = "23:00";
 
 function addMinutesToTime(time: string, minutes: number) {
     var parts = time.split(":");
@@ -40,7 +41,7 @@ export const ServiceProviderBookingPage = () => {
   useEffect(() => {
     const fetchAvailableTimes = async () => { 
       try {
-        const response = await fetch(`${process.env.REACT_APP_BACKEND_HOST}/api/booking/available/${id}?date=${selectedDate}&start_time=${selectedStartTime}`, {
+        const response = await fetch(`${process.env.REACT_APP_BACKEND_HOST}/api/booking/available/${id}?date=${selectedDate}&start_time=${selectedStartTime}&end_time=${end_time}`, {
           method: 'GET',
           headers: {
             'Authorization': `Token ${localStorage.getItem("token")}`,
@@ -156,7 +157,7 @@ export const ServiceProviderBookingPage = () => {
             setSelectedDate(formattedDate);
           }}
         />
-        <TimeSelector selectedTime={selectedStartTime} onTimeChange={setSelectedStartTime} />
+        <TimeSelector selectedTime={selectedStartTime} timeInterval={serviceInformation.session_time ? serviceInformation.session_time : 30} onTimeChange={setSelectedStartTime} />
       </div>
       <div className="mb-3">
         <TimePicker selectedTime={selectedTime} startTime={selectedStartTime} availableTimes={availableTimeslots} interval={serivceTimeInterval} onTimeChange={onTimeChange} />


### PR DESCRIPTION
## What was the issue?
When going to book a service from a service provider, it only showed 3 possible timeslots beeing available. 

## Solution
After investigation, I found a limitation in the code for generating the not booked timeslots, where it only looked 3 hours into the future. I changed this to be user defined over the API instead. The frontend now defaults this to 20:00, but can be changed more dynamically in the future